### PR TITLE
Hotfix for only one width

### DIFF
--- a/Classes/ViewHelpers/GetSrcsetViewHelper.php
+++ b/Classes/ViewHelpers/GetSrcsetViewHelper.php
@@ -90,7 +90,7 @@ class GetSrcsetViewHelper extends AbstractViewHelper
 
         $widths = $this->arguments['widths'];
         if (!is_array($widths)) {
-            $widths = explode(',', $widths);
+            $widths = explode(',', (string) $widths);
         }
 
         /** @var FileInterface $file */


### PR DESCRIPTION
Wenn nur eine Width für den getSourceSet Viewhelper angegeben wird, wird diese als integer interpretiert, wodurch es zu einem Fehler bei explode() kommt. Ein einfacher Cast zu string fixed hier den error.